### PR TITLE
fix: disable any uncertain workflows for debugging

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,50 +1,50 @@
-name: Changelog Release
-on:
-  workflow_call:
-jobs:
-  changelog-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Reset Cancellation Flag
-        run: echo "IS_CANCELLED=false" >> $GITHUB_ENV
-
-      - name: Get latest tag
-        id: get_tag
-        run: |
-          TAG=$(git describe --tags --abbrev=0)
-          if [ -z "$TAG" ]; then
-            echo >&2 "ERROR: No tags found. Cannot create release."
-            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
-          fi
-          echo "TAG=$TAG" >> $GITHUB_ENV
-
-      - name: Generate changelog
-        if: env.IS_CANCELLED == 'false'
-        id: changelog
-        run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^)
-          if [ -z "$PREV_TAG" ]; then
-            echo >&2 "ERROR: No previous tag found. Cannot generate changelog."
-            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
-          fi
-          echo "Generating changelog from $PREV_TAG to $TAG"
-          CHANGELOG=$(git log $PREV_TAG..$TAG --pretty=format:'* %s (%an)' --no-merges)
-          if [ -z "$CHANGELOG" ]; then
-            echo >&2 "No commits found between $PREV_TAG and $TAG. Changelog will be empty."
-          fi
-          echo "$CHANGELOG" > changelog.txt
-
-      - name: Create GitHub Release
-        if: env.IS_CANCELLED == 'false'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.TAG }}
-          name: Release ${{ env.TAG }}
-          body_path: changelog.txt
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#name: Changelog Release
+#on:
+#  workflow_call:
+#jobs:
+#  changelog-release:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v5
+#        with:
+#          fetch-depth: 0
+#
+#      - name: Reset Cancellation Flag
+#        run: echo "IS_CANCELLED=false" >> $GITHUB_ENV
+#
+#      - name: Get latest tag
+#        id: get_tag
+#        run: |
+#          TAG=$(git describe --tags --abbrev=0)
+#          if [ -z "$TAG" ]; then
+#            echo >&2 "ERROR: No tags found. Cannot create release."
+#            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
+#          fi
+#          echo "TAG=$TAG" >> $GITHUB_ENV
+#
+#      - name: Generate changelog
+#        if: env.IS_CANCELLED == 'false'
+#        id: changelog
+#        run: |
+#          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^)
+#          if [ -z "$PREV_TAG" ]; then
+#            echo >&2 "ERROR: No previous tag found. Cannot generate changelog."
+#            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
+#          fi
+#          echo "Generating changelog from $PREV_TAG to $TAG"
+#          CHANGELOG=$(git log $PREV_TAG..$TAG --pretty=format:'* %s (%an)' --no-merges)
+#          if [ -z "$CHANGELOG" ]; then
+#            echo >&2 "No commits found between $PREV_TAG and $TAG. Changelog will be empty."
+#          fi
+#          echo "$CHANGELOG" > changelog.txt
+#
+#      - name: Create GitHub Release
+#        if: env.IS_CANCELLED == 'false'
+#        uses: softprops/action-gh-release@v2
+#        with:
+#          tag_name: ${{ env.TAG }}
+#          name: Release ${{ env.TAG }}
+#          body_path: changelog.txt
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,19 +1,19 @@
-name: CodeQL Analysis
-
-on:
-  workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
-  workflow_call: # Allows this workflow to be called from other workflows.
-
-jobs:
-  codeql:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: kotlin, java
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+#name: CodeQL Analysis
+#
+#on:
+#  workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
+#  workflow_call: # Allows this workflow to be called from other workflows.
+#
+#jobs:
+#  codeql:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v5
+#
+#      - name: Initialize CodeQL
+#        uses: github/codeql-action/init@v3
+#        with:
+#          languages: kotlin, java
+#
+#      - name: Perform CodeQL Analysis
+#        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,21 +1,21 @@
-name: Dependency Submission
-
-on:
-  workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
-  workflow_call: # Allows this workflow to be called from other workflows.
-    secrets: inherit
-
-permissions:
-  contents: write
-
-jobs:
-  dependency-submission:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup Java
-        uses: ./.github/actions/setup-java
-
-      - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v4
+#name: Dependency Submission
+#
+#on:
+#  workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
+#  workflow_call: # Allows this workflow to be called from other workflows.
+#    secrets: inherit
+#
+#permissions:
+#  contents: write
+#
+#jobs:
+#  dependency-submission:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v5
+#
+#      - name: Setup Java
+#        uses: ./.github/actions/setup-java
+#
+#      - name: Generate and submit dependency graph
+#        uses: gradle/actions/dependency-submission@v4

--- a/.github/workflows/maven-central.yml
+++ b/.github/workflows/maven-central.yml
@@ -1,40 +1,40 @@
-# Read this: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-java-packages-with-gradle
-name: Publish to Maven Central
-
-on:
-  workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
-  workflow_call: # Allows this workflow to be called from other workflows.
-
-jobs:
-  publish:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Reset Cancellation Flag
-        run: echo "IS_CANCELLED=false" >> $GITHUB_ENV
-
-      - name: DISABLED - Remove this step to enable job
-        run: |
-          echo "This job is currently disabled. Remove this step to enable."
-          echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 0
-
-      - name: Ensure running on main branch
-        if: ${{ github.ref != 'refs/heads/main' }}
-        run: |
-          echo "This workflow can only be run from the main branch."
-          echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
-
-      - name: Setup Java and Gradle
-        if: env.IS_CANCELLED == 'false'
-        uses: ./.github/actions/setup-gradle
-
-      - name: Publish package
-        if: env.IS_CANCELLED == 'false'
-        run: ./gradlew publish # TODO: Note this is for all publish repos
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+## Read this: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-java-packages-with-gradle
+#name: Publish to Maven Central
+#
+#on:
+#  workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
+#  workflow_call: # Allows this workflow to be called from other workflows.
+#
+#jobs:
+#  publish:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: read
+#      packages: write
+#    steps:
+#      - uses: actions/checkout@v5
+#
+#      - name: Reset Cancellation Flag
+#        run: echo "IS_CANCELLED=false" >> $GITHUB_ENV
+#
+#      - name: DISABLED - Remove this step to enable job
+#        run: |
+#          echo "This job is currently disabled. Remove this step to enable."
+#          echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 0
+#
+#      - name: Ensure running on main branch
+#        if: ${{ github.ref != 'refs/heads/main' }}
+#        run: |
+#          echo "This workflow can only be run from the main branch."
+#          echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
+#
+#      - name: Setup Java and Gradle
+#        if: env.IS_CANCELLED == 'false'
+#        uses: ./.github/actions/setup-gradle
+#
+#      - name: Publish package
+#        if: env.IS_CANCELLED == 'false'
+#        run: ./gradlew publish # TODO: Note this is for all publish repos
+#        env:
+#          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+#          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,13 +15,13 @@ jobs:
   dokka:
     uses: ./.github/workflows/dokka.yml
 
-  dependency-submission:
-    uses: ./.github/workflows/dependency-submission.yml
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+#  dependency-submission:
+#    uses: ./.github/workflows/dependency-submission.yml
+#    secrets:
+#      token: ${{ secrets.GITHUB_TOKEN }}
 
   github-packages:
     uses: ./.github/workflows/github-packages.yml
-    needs: [dokka, dependency-submission ]
+    needs: [dokka] #, dependency-submission ]
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,140 +1,140 @@
-# This workflow increments the minor version and resets patch for human authors,
-# increments patch for bots, and triggers a release only for major/minor bumps.
-name: Version Bump
-
-on:
-  workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
-  workflow_call: # Allows this workflow to be called from other workflows.
-
-permissions:
-  contents: write
-  pull-requests: write
-
-jobs:
-  version-bump:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout PR Branch
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Reset Cancellation Flag
-        run: echo "IS_CANCELLED=false" >> $GITHUB_ENV
-
-      - name: Ensure PR targets main branch
-        if: ${{ github.event.pull_request.base.ref != 'main' }}
-        run: |
-          echo "This PR does not target main. Skipping versioning."
-          echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 0
-
-      - name: Get PR author type
-        if: env.IS_CANCELLED == 'false'
-        id: author
-        run: |
-          if [[ "${{ github.event.pull_request.user.login }}" == *bot* ]]; then
-            echo "author_type=bot" >> $GITHUB_ENV
-          else
-            echo "author_type=human" >> $GITHUB_ENV
-          fi
-
-      - name: Get current version
-        if: env.IS_CANCELLED == 'false'
-        id: get_version
-        run: |
-          MAJOR=$(grep 'project-version-major' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
-          MINOR=$(grep 'project-version-minor' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
-          PATCH=$(grep 'project-version-patch' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
-          if ! [[ "$MAJOR" =~ ^[0-9]+$ && "$MINOR" =~ ^[0-9]+$ && "$PATCH" =~ ^[0-9]+$ ]]; then
-            echo >&2 "ERROR: Version fields in libs.versions.toml must be numbers. Found: major='$MAJOR', minor='$MINOR', patch='$PATCH'"
-            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
-          fi
-          echo "current_version=$MAJOR.$MINOR.$PATCH" >> $GITHUB_ENV
-          echo "MAJOR=$MAJOR" >> $GITHUB_ENV
-          echo "MINOR=$MINOR" >> $GITHUB_ENV
-          echo "PATCH=$PATCH" >> $GITHUB_ENV
-
-      - name: Get previous version from main branch
-        if: env.IS_CANCELLED == 'false'
-        id: get_prev_version
-        run: |
-          git fetch origin main
-          PREV_MAJOR=$(git show origin/main:gradle/libs.versions.toml | grep 'project-version-major' | cut -d'=' -f2 | tr -d ' "')
-          PREV_MINOR=$(git show origin/main:gradle/libs.versions.toml | grep 'project-version-minor' | cut -d'=' -f2 | tr -d ' "')
-          PREV_PATCH=$(git show origin/main:gradle/libs.versions.toml | grep 'project-version-patch' | cut -d'=' -f2 | tr -d ' "')
-          if ! [[ "$PREV_MAJOR" =~ ^[0-9]+$ && "$PREV_MINOR" =~ ^[0-9]+$ && "$PREV_PATCH" =~ ^[0-9]+$ ]]; then
-            echo >&2 "ERROR: Previous version fields in main branch libs.versions.toml must be numbers. Found: major='$PREV_MAJOR', minor='$PREV_MINOR', patch='$PREV_PATCH'"
-            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
-          fi
-          echo "prev_version=$PREV_MAJOR.$PREV_MINOR.$PREV_PATCH" >> $GITHUB_ENV
-          echo "PREV_MAJOR=$PREV_MAJOR" >> $GITHUB_ENV
-          echo "PREV_MINOR=$PREV_MINOR" >> $GITHUB_ENV
-          echo "PREV_PATCH=$PREV_PATCH" >> $GITHUB_ENV
-
-      - name: Cancel if already versioned
-        if: env.IS_CANCELLED == 'false'
-        run: |
-          if [[ "$MAJOR" != "$PREV_MAJOR" || "$MINOR" != "$PREV_MINOR" || "$PATCH" != "$PREV_PATCH" ]]; then
-            echo "Version already incremented (major, minor, or patch differs from main). Cancelling workflow."
-            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 0
-          fi
-
-      - name: Increment version
-        if: env.IS_CANCELLED == 'false'
-        id: increment_version
-        run: |
-          # Defensive: ensure all values are integers
-          MAJOR=${MAJOR:-0}
-          MINOR=${MINOR:-0}
-          PATCH=${PATCH:-0}
-          PREV_MAJOR=${PREV_MAJOR:-0}
-          PREV_MINOR=${PREV_MINOR:-0}
-          PREV_PATCH=${PREV_PATCH:-0}
-
-          if [[ "$MAJOR" -gt "$PREV_MAJOR" ]]; then
-            # Manual major bump detected
-            MINOR=0
-            PATCH=0
-            echo "Manual major bump detected. Minor and patch reset to 0."
-          elif [[ "$author_type" == "human" ]]; then
-            MINOR=$((MINOR+1))
-            PATCH=0
-            echo "Author is human. Minor version increased, and patch reset to 0."
-          else
-            PATCH=$((PATCH+1))
-            echo "Author is bot. Patch version increased."
-          fi
-          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-          echo "new_version=$NEW_VERSION" >> $GITHUB_ENV
-          echo "MAJOR=$MAJOR" >> $GITHUB_ENV
-          echo "MINOR=$MINOR" >> $GITHUB_ENV
-          echo "PATCH=$PATCH" >> $GITHUB_ENV
-
-      - name: Update version in libs.versions.toml
-        if: env.IS_CANCELLED == 'false'
-        run: |
-          # Use portable sed for both macOS and Linux
-          if sed --version 2>/dev/null | grep -q GNU; then
-            SED_CMD="sed -i"
-          else
-            SED_CMD="sed -i ''"
-          fi
-          $SED_CMD -E "s/project-version-major[ ]*=[ ]*\"[0-9]+\"/project-version-major = \"$MAJOR\"/" gradle/libs.versions.toml
-          $SED_CMD -E "s/project-version-minor[ ]*=[ ]*\"[0-9]+\"/project-version-minor = \"$MINOR\"/" gradle/libs.versions.toml
-          $SED_CMD -E "s/project-version-patch[ ]*=[ ]*\"[0-9]+\"/project-version-patch = \"$PATCH\"/" gradle/libs.versions.toml
-          echo "Updated version lines:" && grep 'project-version-' gradle/libs.versions.toml
-
-      - name: Commit and push version bump
-        if: env.IS_CANCELLED == 'false'
-        run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-          git add gradle/libs.versions.toml
-          if git diff --cached --exit-code; then
-            echo "No changes to commit. Skipping push."
-            exit 0
-          fi
-          git commit -m "Bump version to $new_version"
-          git push origin HEAD:${{ github.head_ref }}
+## This workflow increments the minor version and resets patch for human authors,
+## increments patch for bots, and triggers a release only for major/minor bumps.
+#name: Version Bump
+#
+#on:
+#  workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
+#  workflow_call: # Allows this workflow to be called from other workflows.
+#
+#permissions:
+#  contents: write
+#  pull-requests: write
+#
+#jobs:
+#  version-bump:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout PR Branch
+#        uses: actions/checkout@v5
+#        with:
+#          fetch-depth: 0
+#          ref: ${{ github.head_ref }}
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Reset Cancellation Flag
+#        run: echo "IS_CANCELLED=false" >> $GITHUB_ENV
+#
+#      - name: Ensure PR targets main branch
+#        if: ${{ github.event.pull_request.base.ref != 'main' }}
+#        run: |
+#          echo "This PR does not target main. Skipping versioning."
+#          echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 0
+#
+#      - name: Get PR author type
+#        if: env.IS_CANCELLED == 'false'
+#        id: author
+#        run: |
+#          if [[ "${{ github.event.pull_request.user.login }}" == *bot* ]]; then
+#            echo "author_type=bot" >> $GITHUB_ENV
+#          else
+#            echo "author_type=human" >> $GITHUB_ENV
+#          fi
+#
+#      - name: Get current version
+#        if: env.IS_CANCELLED == 'false'
+#        id: get_version
+#        run: |
+#          MAJOR=$(grep 'project-version-major' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
+#          MINOR=$(grep 'project-version-minor' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
+#          PATCH=$(grep 'project-version-patch' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
+#          if ! [[ "$MAJOR" =~ ^[0-9]+$ && "$MINOR" =~ ^[0-9]+$ && "$PATCH" =~ ^[0-9]+$ ]]; then
+#            echo >&2 "ERROR: Version fields in libs.versions.toml must be numbers. Found: major='$MAJOR', minor='$MINOR', patch='$PATCH'"
+#            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
+#          fi
+#          echo "current_version=$MAJOR.$MINOR.$PATCH" >> $GITHUB_ENV
+#          echo "MAJOR=$MAJOR" >> $GITHUB_ENV
+#          echo "MINOR=$MINOR" >> $GITHUB_ENV
+#          echo "PATCH=$PATCH" >> $GITHUB_ENV
+#
+#      - name: Get previous version from main branch
+#        if: env.IS_CANCELLED == 'false'
+#        id: get_prev_version
+#        run: |
+#          git fetch origin main
+#          PREV_MAJOR=$(git show origin/main:gradle/libs.versions.toml | grep 'project-version-major' | cut -d'=' -f2 | tr -d ' "')
+#          PREV_MINOR=$(git show origin/main:gradle/libs.versions.toml | grep 'project-version-minor' | cut -d'=' -f2 | tr -d ' "')
+#          PREV_PATCH=$(git show origin/main:gradle/libs.versions.toml | grep 'project-version-patch' | cut -d'=' -f2 | tr -d ' "')
+#          if ! [[ "$PREV_MAJOR" =~ ^[0-9]+$ && "$PREV_MINOR" =~ ^[0-9]+$ && "$PREV_PATCH" =~ ^[0-9]+$ ]]; then
+#            echo >&2 "ERROR: Previous version fields in main branch libs.versions.toml must be numbers. Found: major='$PREV_MAJOR', minor='$PREV_MINOR', patch='$PREV_PATCH'"
+#            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
+#          fi
+#          echo "prev_version=$PREV_MAJOR.$PREV_MINOR.$PREV_PATCH" >> $GITHUB_ENV
+#          echo "PREV_MAJOR=$PREV_MAJOR" >> $GITHUB_ENV
+#          echo "PREV_MINOR=$PREV_MINOR" >> $GITHUB_ENV
+#          echo "PREV_PATCH=$PREV_PATCH" >> $GITHUB_ENV
+#
+#      - name: Cancel if already versioned
+#        if: env.IS_CANCELLED == 'false'
+#        run: |
+#          if [[ "$MAJOR" != "$PREV_MAJOR" || "$MINOR" != "$PREV_MINOR" || "$PATCH" != "$PREV_PATCH" ]]; then
+#            echo "Version already incremented (major, minor, or patch differs from main). Cancelling workflow."
+#            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 0
+#          fi
+#
+#      - name: Increment version
+#        if: env.IS_CANCELLED == 'false'
+#        id: increment_version
+#        run: |
+#          # Defensive: ensure all values are integers
+#          MAJOR=${MAJOR:-0}
+#          MINOR=${MINOR:-0}
+#          PATCH=${PATCH:-0}
+#          PREV_MAJOR=${PREV_MAJOR:-0}
+#          PREV_MINOR=${PREV_MINOR:-0}
+#          PREV_PATCH=${PREV_PATCH:-0}
+#
+#          if [[ "$MAJOR" -gt "$PREV_MAJOR" ]]; then
+#            # Manual major bump detected
+#            MINOR=0
+#            PATCH=0
+#            echo "Manual major bump detected. Minor and patch reset to 0."
+#          elif [[ "$author_type" == "human" ]]; then
+#            MINOR=$((MINOR+1))
+#            PATCH=0
+#            echo "Author is human. Minor version increased, and patch reset to 0."
+#          else
+#            PATCH=$((PATCH+1))
+#            echo "Author is bot. Patch version increased."
+#          fi
+#          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+#          echo "new_version=$NEW_VERSION" >> $GITHUB_ENV
+#          echo "MAJOR=$MAJOR" >> $GITHUB_ENV
+#          echo "MINOR=$MINOR" >> $GITHUB_ENV
+#          echo "PATCH=$PATCH" >> $GITHUB_ENV
+#
+#      - name: Update version in libs.versions.toml
+#        if: env.IS_CANCELLED == 'false'
+#        run: |
+#          # Use portable sed for both macOS and Linux
+#          if sed --version 2>/dev/null | grep -q GNU; then
+#            SED_CMD="sed -i"
+#          else
+#            SED_CMD="sed -i ''"
+#          fi
+#          $SED_CMD -E "s/project-version-major[ ]*=[ ]*\"[0-9]+\"/project-version-major = \"$MAJOR\"/" gradle/libs.versions.toml
+#          $SED_CMD -E "s/project-version-minor[ ]*=[ ]*\"[0-9]+\"/project-version-minor = \"$MINOR\"/" gradle/libs.versions.toml
+#          $SED_CMD -E "s/project-version-patch[ ]*=[ ]*\"[0-9]+\"/project-version-patch = \"$PATCH\"/" gradle/libs.versions.toml
+#          echo "Updated version lines:" && grep 'project-version-' gradle/libs.versions.toml
+#
+#      - name: Commit and push version bump
+#        if: env.IS_CANCELLED == 'false'
+#        run: |
+#          git config --global user.name "github-actions"
+#          git config --global user.email "github-actions@github.com"
+#          git add gradle/libs.versions.toml
+#          if git diff --cached --exit-code; then
+#            echo "No changes to commit. Skipping push."
+#            exit 0
+#          fi
+#          git commit -m "Bump version to $new_version"
+#          git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -1,72 +1,72 @@
-name: Version Tag
-
-on:
-  workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
-  workflow_call: # Allows this workflow to be called from other workflows.
-
-jobs:
-  tag-version:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Reset Cancellation Flag
-        run: echo "IS_CANCELLED=false" >> $GITHUB_ENV
-
-      - name: Get current version
-        id: get_version
-        run: |
-          MAJOR=$(grep 'project-version-major' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
-          MINOR=$(grep 'project-version-minor' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
-          PATCH=$(grep 'project-version-patch' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
-          if ! [[ "$MAJOR" =~ ^[0-9]+$ && "$MINOR" =~ ^[0-9]+$ && "$PATCH" =~ ^[0-9]+$ ]]; then
-            echo >&2 "ERROR: Version fields in libs.versions.toml must be numbers. Found: major='$MAJOR', minor='$MINOR', patch='$PATCH'"
-            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
-          fi
-          echo "MAJOR=$MAJOR" >> $GITHUB_ENV
-          echo "MINOR=$MINOR" >> $GITHUB_ENV
-          echo "PATCH=$PATCH" >> $GITHUB_ENV
-
-      - name: Get previous version from previous commit
-        if: env.IS_CANCELLED == 'false'
-        id: get_prev_version
-        run: |
-          PREV_MAJOR=$(git show HEAD^:gradle/libs.versions.toml | grep 'project-version-major' | cut -d'=' -f2 | tr -d ' "')
-          PREV_MINOR=$(git show HEAD^:gradle/libs.versions.toml | grep 'project-version-minor' | cut -d'=' -f2 | tr -d ' "')
-          PREV_PATCH=$(git show HEAD^:gradle/libs.versions.toml | grep 'project-version-patch' | cut -d'=' -f2 | tr -d ' "')
-          if ! [[ "$PREV_MAJOR" =~ ^[0-9]+$ && "$PREV_MINOR" =~ ^[0-9]+$ && "$PREV_PATCH" =~ ^[0-9]+$ ]]; then
-            echo >&2 "ERROR: Previous version fields in previous commit must be numbers. Found: major='$PREV_MAJOR', minor='$PREV_MINOR', patch='$PREV_PATCH'"
-            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
-          fi
-          echo "PREV_MAJOR=$PREV_MAJOR" >> $GITHUB_ENV
-          echo "PREV_MINOR=$PREV_MINOR" >> $GITHUB_ENV
-          echo "PREV_PATCH=$PREV_PATCH" >> $GITHUB_ENV
-
-      - name: Cancel if only patch increased
-        if: env.IS_CANCELLED == 'false'
-        run: |
-          if [[ "$MAJOR" == "$PREV_MAJOR" && "$MINOR" == "$PREV_MINOR" && "$PATCH" != "$PREV_PATCH" ]]; then
-            echo "Only patch version increased. No tag will be created."
-            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 0
-          fi
-          if [[ "$MAJOR" == "$PREV_MAJOR" && "$MINOR" == "$PREV_MINOR" && "$PATCH" == "$PREV_PATCH" ]]; then
-            echo >&2 "No version change detected. No tag will be created."
-            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
-          fi
-
-      - name: Create version tag
-        if: env.IS_CANCELLED == 'false'
-        run: |
-          TAG="v$MAJOR.$MINOR.$PATCH"
-          # Defensive: check if tag already exists
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo >&2 "Tag $TAG already exists. Skipping tag creation."
-            exit 1
-          fi
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-          git tag "$TAG"
-          git push origin "$TAG"
+#name: Version Tag
+#
+#on:
+#  workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
+#  workflow_call: # Allows this workflow to be called from other workflows.
+#
+#jobs:
+#  tag-version:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v5
+#        with:
+#          fetch-depth: 0
+#
+#      - name: Reset Cancellation Flag
+#        run: echo "IS_CANCELLED=false" >> $GITHUB_ENV
+#
+#      - name: Get current version
+#        id: get_version
+#        run: |
+#          MAJOR=$(grep 'project-version-major' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
+#          MINOR=$(grep 'project-version-minor' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
+#          PATCH=$(grep 'project-version-patch' gradle/libs.versions.toml | cut -d'=' -f2 | tr -d ' "')
+#          if ! [[ "$MAJOR" =~ ^[0-9]+$ && "$MINOR" =~ ^[0-9]+$ && "$PATCH" =~ ^[0-9]+$ ]]; then
+#            echo >&2 "ERROR: Version fields in libs.versions.toml must be numbers. Found: major='$MAJOR', minor='$MINOR', patch='$PATCH'"
+#            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
+#          fi
+#          echo "MAJOR=$MAJOR" >> $GITHUB_ENV
+#          echo "MINOR=$MINOR" >> $GITHUB_ENV
+#          echo "PATCH=$PATCH" >> $GITHUB_ENV
+#
+#      - name: Get previous version from previous commit
+#        if: env.IS_CANCELLED == 'false'
+#        id: get_prev_version
+#        run: |
+#          PREV_MAJOR=$(git show HEAD^:gradle/libs.versions.toml | grep 'project-version-major' | cut -d'=' -f2 | tr -d ' "')
+#          PREV_MINOR=$(git show HEAD^:gradle/libs.versions.toml | grep 'project-version-minor' | cut -d'=' -f2 | tr -d ' "')
+#          PREV_PATCH=$(git show HEAD^:gradle/libs.versions.toml | grep 'project-version-patch' | cut -d'=' -f2 | tr -d ' "')
+#          if ! [[ "$PREV_MAJOR" =~ ^[0-9]+$ && "$PREV_MINOR" =~ ^[0-9]+$ && "$PREV_PATCH" =~ ^[0-9]+$ ]]; then
+#            echo >&2 "ERROR: Previous version fields in previous commit must be numbers. Found: major='$PREV_MAJOR', minor='$PREV_MINOR', patch='$PREV_PATCH'"
+#            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
+#          fi
+#          echo "PREV_MAJOR=$PREV_MAJOR" >> $GITHUB_ENV
+#          echo "PREV_MINOR=$PREV_MINOR" >> $GITHUB_ENV
+#          echo "PREV_PATCH=$PREV_PATCH" >> $GITHUB_ENV
+#
+#      - name: Cancel if only patch increased
+#        if: env.IS_CANCELLED == 'false'
+#        run: |
+#          if [[ "$MAJOR" == "$PREV_MAJOR" && "$MINOR" == "$PREV_MINOR" && "$PATCH" != "$PREV_PATCH" ]]; then
+#            echo "Only patch version increased. No tag will be created."
+#            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 0
+#          fi
+#          if [[ "$MAJOR" == "$PREV_MAJOR" && "$MINOR" == "$PREV_MINOR" && "$PATCH" == "$PREV_PATCH" ]]; then
+#            echo >&2 "No version change detected. No tag will be created."
+#            echo "IS_CANCELLED=true" >> $GITHUB_ENV && exit 1
+#          fi
+#
+#      - name: Create version tag
+#        if: env.IS_CANCELLED == 'false'
+#        run: |
+#          TAG="v$MAJOR.$MINOR.$PATCH"
+#          # Defensive: check if tag already exists
+#          if git rev-parse "$TAG" >/dev/null 2>&1; then
+#            echo >&2 "Tag $TAG already exists. Skipping tag creation."
+#            exit 1
+#          fi
+#          git config --global user.name "github-actions"
+#          git config --global user.email "github-actions@github.com"
+#          git tag "$TAG"
+#          git push origin "$TAG"


### PR DESCRIPTION
This pull request disables several GitHub Actions workflows by commenting out their contents, effectively preventing them from running in CI/CD. The affected workflows include version bumping, changelog release, dependency submission, CodeQL analysis, and publishing to Maven Central. Additionally, the `publish.yml` workflow is updated to remove its dependency on the now-disabled dependency submission workflow.

Workflows disabled:

* Disabled the entire `Version Bump` workflow by commenting out its contents in `.github/workflows/version-bump.yml`.
* Disabled the entire `Changelog Release` workflow by commenting out its contents in `.github/workflows/changelog.yml`.
* Disabled the entire `Dependency Submission` workflow by commenting out its contents in `.github/workflows/dependency-submission.yml`.
* Disabled the entire `CodeQL Analysis` workflow by commenting out its contents in `.github/workflows/codeql.yml`.
* Disabled the entire `Publish to Maven Central` workflow by commenting out its contents in `.github/workflows/maven-central.yml`.

Workflow dependency updates:

* Removed the `dependency-submission` job and its dependency from the `github-packages` job in `.github/workflows/publish.yml`, reflecting the disabled dependency submission workflow.